### PR TITLE
Created postgres db, and add bikeway network data

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,12 @@
+FROM postgres:10.5
+
+RUN apt-get update && apt-get install -y postgresql-10-postgis-2.4 unzip curl postgis
+
+ENV POSTGRES_USER bikelanes
+ENV POSTGRES_PASSWORD bike_pass
+ENV POSTGRES_DB bikelanes
+
+RUN mkdir /data
+RUN cd /data && curl "https://data.sfgov.org/api/geospatial/4jy4-tbju?method=export&format=Shapefile" > /data/data.zip && unzip /data/data.zip
+RUN shp2pgsql -s 4326 /data/*.shp public.bikeway_network > /data/bikeway_network.sql
+RUN echo 'CREATE EXTENSION postgis;' | cat - /data/bikeway_network.sql > /data/temp && mv /data/temp /data/bikeway_network.sql

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,31 @@
+# Bikeway Network DB
+
+[Bikeway Network data](https://data.sfgov.org/Transportation/Bikeway-Network/4jy4-tbju) provides information on sf bike paths.
+
+## Local DB
+
+### Setup
+
+In the base project directory, the following commands can be run to get the bike data loaded:
+```
+yarn build:db
+yarn seed:db
+yarn run:db
+```
+
+### Usage
+
+You can connect to the db using `yarn db` where the relation `bikeway_network` contains all of the data. A sample query to find the best bikepath within 3 meters of a point:
+```
+SELECT gid, install_yr, symbology, streetname, st_DistanceSphere(geom, ST_MakePoint(-122.4587284, 37.74675537)) as dist 
+FROM bikeway_network 
+WHERE st_DistanceSphere(geom, ST_MakePoint(-122.4587284, 37.74675537)) <= 3
+ORDER BY dist LIMIT 1;
+```
+
+## Remote DB
+
+Use the following to connect to our db:
+```
+PGPASSWORD=<<PASSWORD>> psql bikelane bikelanes --host bikelanes.cl6adk7d8ywn.us-east-1.rds.amazonaws.com
+```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "",
   "main": "config_default.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build:db": "docker build -t db ./db/",
+    "run:db": "docker run --name db db",
+    "seed:db": "docker exec -it db bash -c 'psql bikelanes bikelanes -f /data/bikeway_network.sql'",
+    "db": "docker exec -it db bash -c 'psql bikelanes bikelanes'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
A bit of a work in progress but I spent some time setting up our postgres db, installing the postgis extension, and also adding a docker container for local usage.

The readme has a sample query you can run which gets the closest bikeway within 3 meters of a point. We'll probably have to adjust this to what makes sense but 10 feet seems about right, and if nothing returns, then that means the user/bike-rider wasn't on a designated bike path.

```
SELECT gid, install_yr, symbology, streetname, st_DistanceSphere(geom, ST_MakePoint(-122.4587284, 37.74675537)) as dist FROM bikeway_network WHERE st_DistanceSphere(geom, ST_MakePoint(-122.4587284, 37.74675537)) <= 3
ORDER BY dist LIMIT 1;
```

The next steps with this would be now to combine the resulting bike path that's returned from the above query with our 311 data, so we can tie incident reporting w/ what kind of bike path it's on (or think of other good uses of this data).