### PR TITLE
SF 311 case seeding logic and ActiveRecord PostGIS updates

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -9,7 +9,6 @@
 In the base project directory, the following commands can be run to get the bike data loaded:
 ```
 yarn build:db
-yarn db:seed
 yarn db:run
 ```
 

--- a/lanebreach-api/Gemfile
+++ b/lanebreach-api/Gemfile
@@ -21,6 +21,8 @@ gem 'soda-ruby', :require => 'soda'
 gem 'will_paginate'
 gem 'api-pagination'
 
+gem 'activerecord-import'
+
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 

--- a/lanebreach-api/Gemfile.lock
+++ b/lanebreach-api/Gemfile.lock
@@ -33,6 +33,8 @@ GEM
       activemodel (= 5.2.1)
       activesupport (= 5.2.1)
       arel (>= 9.0)
+    activerecord-import (0.27.0)
+      activerecord (>= 3.2)
     activerecord-postgis-adapter (5.2.1)
       activerecord (~> 5.1)
       rgeo-activerecord (~> 6.0)
@@ -157,6 +159,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import
   activerecord-postgis-adapter
   annotate
   api-pagination

--- a/lanebreach-api/README.md
+++ b/lanebreach-api/README.md
@@ -69,48 +69,54 @@ null
 
 **request:**
 ```
-curl -XGET https://lane-breach.herokuapp.com/api/sf311_case/bike_lane_blockages?start_time=2018-6-15&end_time=2018-6-17
+curl -XGET https://lane-breach.herokuapp.com/api/sf311_cases?start_time=2018-6-15&end_time=2018-6-17
 ```
+
+`page` and `per_page` query string parameters can also be specified for paging through the result set.
+The default page size is 30 items.
 
 **response:**
 ```
-{
-  "id": 1,
-  "address": "2927 FOLSOM ST, SAN FRANCISCO, CA, 94110",
-  "agency_responsible": "Parking Enforcement Review Queue",
-  "closed_date": "2018-06-16T15:14:09.000",
-  "lat": "37.75041",
-  "long": "-122.4138",
-  "neighborhoods_sffind_boundaries": "Mission",
-  "point": {
-  "type": "Point",
-    "coordinates": [
-      -122.41369887,
-      37.75039981
-    ]
+[
+  {
+    "id": 1,
+    "service_request_id": 9145772,
+    "requested_datetime": "2018-06-16T15:14:02.000Z",
+    "closed_date": "2018-06-16T15:14:09.000Z",
+    "updated_datetime": "2018-06-16T15:14:09.000Z",
+    "status_description": "Closed",
+    "status_notes": "The report has been logged and will help the City collect data on double parking and bike lane violations to determine target areas and future enforcement efforts. Thank you.",
+    "agency_responsible": "Parking Enforcement Review Queue",
+    "service_name": "Parking Enforcement",
+    "service_subtype": "Blocking_Bicycle_Lane",
+    "service_details": "Parking Enforcement",
+    "address": "2927 FOLSOM ST, SAN FRANCISCO, CA, 94110",
+    "supervisor_district": 9,
+    "neighborhoods_sffind_boundaries": "Mission",
+    "police_district": "MISSION",
+    "lat": 37.75041,
+    "long": -122.4138,
+    "point": "POINT (-122.41369887 37.75039981)",
+    "point_city": null,
+    "source": "Mobile/Open311",
+    "point_state": null,
+    "point_address": null,
+    "point_zip": null,
+    "media_url_description": null,
+    "media_url": null,
+    "created_at": "2018-11-24T19:54:31.565Z",
+    "updated_at": "2018-11-24T19:54:31.565Z"
   },
-  "police_district": "MISSION",
-  "requested_datetime": "2018-06-16T15:14:02.000",
-  "service_details": "Parking Enforcement",
-  "service_name": "Parking Enforcement",
-  "service_request_id": "9145772",
-  "service_subtype": "Blocking_Bicycle_Lane",
-  "source": "Mobile/Open311",
-  "status_description": "Closed",
-  "status_notes": "The report has been logged and will help the City collect data on double parking and bike lane violations to determine target areas and future enforcement efforts. Thank you.",
-  "supervisor_district": "9",
-  "updated_datetime": "2018-06-16T15:14:09.000"
-  "created_at": "2018-11-17T00:36:41+00:00"
-  "updated_at": "2018-11-17T00:36:41+00:00"
-},
-...
+  ...
+]
 ```
 
 #### POST /api/sf311_cases
 
+```
 **request:**
 ```
-curl -XPOST https://lane-breach.herokuapp.com/api/sf311_case -H "Content-Type: application/json" -d
+curl -XPOST https://lane-breach.herokuapp.com/api/sf311_cases -H "Content-Type: application/json" -d
   '{
     "sf311_case": {
       "address": "326 14TH ST, SAN FRANCISCO, CA, 94103",

--- a/lanebreach-api/app/controllers/api/sf311_cases_controller.rb
+++ b/lanebreach-api/app/controllers/api/sf311_cases_controller.rb
@@ -1,7 +1,18 @@
 class Api::Sf311CasesController < ApplicationController
   def index
-    data = Sf311CaseService.get_blocked_bike_lane_cases
-    render json: data, status: :ok
+    lane_blockages_query = Sf311Case.bike_lane_blockage
+
+    if params[:start_time]
+      lane_blockages_query =
+        lane_blockages_query.where('requested_datetime >= ?', params[:start_time])
+    end
+
+    if params[:end_time]
+      lane_blockages_query =
+        lane_blockages_query.where('requested_datetime <= ?', params[:end_time])
+    end
+
+    paginate json: lane_blockages_query
   end
 
   def create
@@ -16,22 +27,6 @@ class Api::Sf311CasesController < ApplicationController
     else
       render json: { 'Error': 'Error creating new 311 case' }, status: :unprocessable_entity
     end
-  end
-
-  def bike_lane_blockages
-    lane_blockages_query = Sf311Case.bike_lane_blockage
-
-    if params[:start_time]
-      lane_blockages_query =
-        lane_blockages_query.where('requested_datetime >= ?', params[:start_time])
-    end
-
-    if params[:end_time]
-      lane_blockages_query =
-        lane_blockages_query.where('requested_datetime <= ?', params[:end_time])
-    end
-
-    paginate json: lane_blockages_query, per_page: 10
   end
 
   private

--- a/lanebreach-api/app/models/bikeway_network.rb
+++ b/lanebreach-api/app/models/bikeway_network.rb
@@ -16,7 +16,7 @@
 #  facility_t :string(254)
 #  from_st    :string(254)
 #  fy         :decimal(, )
-#  geom       :geometry(MultiLi
+#  geom       :geometry({:srid= multilinestring, 4326
 #  gid        :integer          not null, primary key
 #  globalid   :string(254)
 #  greenwave  :string(254)

--- a/lanebreach-api/app/models/sf311_case.rb
+++ b/lanebreach-api/app/models/sf311_case.rb
@@ -11,7 +11,7 @@
 #  media_url                       :string
 #  media_url_description           :string
 #  neighborhoods_sffind_boundaries :string
-#  point                           :point
+#  point                           :geography({:srid point, 4326
 #  point_address                   :string
 #  point_city                      :string
 #  point_state                     :string

--- a/lanebreach-api/app/services/sf311_case_service.rb
+++ b/lanebreach-api/app/services/sf311_case_service.rb
@@ -15,8 +15,11 @@ module Sf311CaseService
   # https://dev.socrata.com/docs/datatypes/floating_timestamp.html
   SODA_FLOATING_TIMESTAMP_FORMAT ='%Y-%m-%dT%T'
 
-  def get_blocked_bike_lane_cases
-    get_cases(Sf311Case::SERVICE_SUBTYPES[:blocked_bike_lane])
+  def get_blocked_bike_lane_case_data(options = {})
+    get_cases(
+      Sf311Case::SERVICE_SUBTYPES[:blocked_bike_lane],
+      options
+    )
   end
 
   def create_case(case_attributes)
@@ -34,7 +37,7 @@ module Sf311CaseService
     @client ||= SODA::Client.new(SODA_CREDENTIALS)
   end
 
-  def get_cases(subtype, from_datetime: nil, to_datetime: nil, offset: 0, limit: 10)
+  def get_cases(subtype, from_datetime: nil, to_datetime: nil, offset: 0, limit: 10, format: :json)
     request_params = {
       service_subtype: subtype,
       '$offset': offset,
@@ -55,6 +58,10 @@ module Sf311CaseService
 
     request_params['$where'] = query_conditions.join(' and ') if query_conditions
 
-    client.get(CASE_DATASET_ID, request_params)
+    client.get(
+      "https://data.sfgov.org/resource/#{CASE_DATASET_ID}.#{format}",
+      request_params
+    )
   end
+
 end

--- a/lanebreach-api/config/database.yml
+++ b/lanebreach-api/config/database.yml
@@ -1,5 +1,5 @@
 default: &default
-  adapter: postgresql
+  adapter: postgis
   encoding: unicode
   username: postgres
   password:
@@ -15,7 +15,7 @@ development:
   password: bike_pass
 
 production:
-  adapter: postgresql
+  adapter: postgis
   encoding: unicode
   database: <%= ENV['RDS_DB_NAME'] %>
   username: <%= ENV['RDS_USERNAME'] %>

--- a/lanebreach-api/config/routes.rb
+++ b/lanebreach-api/config/routes.rb
@@ -6,6 +6,5 @@ Rails.application.routes.draw do
     get '/bikeway_networks', to: 'bikeway_networks#nearest_network'
 
     resources :sf311_cases, only: [:index, :create]
-    get '/sf311_cases/bike_lane_blockages', to:'sf311_cases#bike_lane_blockages'
   end
 end

--- a/lanebreach-api/db/migrate/20181108031609_add_sf311_cases_data.rb
+++ b/lanebreach-api/db/migrate/20181108031609_add_sf311_cases_data.rb
@@ -17,7 +17,7 @@ class AddSf311CasesData < ActiveRecord::Migration[5.2]
       t.string :police_district
       t.float :lat
       t.float :long
-      t.point :point
+      t.st_point :point, geographic: true
       t.string :point_city
       t.string :source
       t.string :point_state

--- a/lanebreach-api/db/schema.rb
+++ b/lanebreach-api/db/schema.rb
@@ -16,8 +16,46 @@ ActiveRecord::Schema.define(version: 2018_11_08_031609) do
   enable_extension "plpgsql"
   enable_extension "postgis"
 
-# Could not dump table "bikeway_networks" because of following StandardError
-#   Unknown type 'geometry(MultiLineString,4326)' for column 'geom'
+  create_table "bikeway_networks", primary_key: "gid", id: :serial, force: :cascade do |t|
+    t.string "barrier", limit: 254
+    t.string "biap", limit: 254
+    t.string "buffered", limit: 254
+    t.decimal "cnn"
+    t.string "contraflow", limit: 254
+    t.date "date_creat"
+    t.string "time_creat", limit: 254
+    t.string "created_us", limit: 254
+    t.string "dir", limit: 254
+    t.string "direct", limit: 254
+    t.decimal "double"
+    t.string "facility_t", limit: 254
+    t.string "from_st", limit: 254
+    t.decimal "fy"
+    t.string "globalid", limit: 254
+    t.string "greenwave", limit: 254
+    t.decimal "install_mo"
+    t.decimal "install_yr"
+    t.date "date_last_"
+    t.string "time_last_", limit: 254
+    t.string "last_edite", limit: 254
+    t.decimal "length"
+    t.string "notes", limit: 254
+    t.string "number", limit: 254
+    t.decimal "objectid"
+    t.decimal "qtr"
+    t.string "raised", limit: 254
+    t.decimal "shape_len"
+    t.decimal "sharrow"
+    t.string "sm_sweeper", limit: 254
+    t.string "street", limit: 254
+    t.string "streetname", limit: 254
+    t.string "surface_tr", limit: 254
+    t.string "symbology", limit: 254
+    t.string "to_st", limit: 254
+    t.decimal "update_mo"
+    t.decimal "update_yr"
+    t.geometry "geom", limit: {:srid=>4326, :type=>"multi_line_string"}
+  end
 
   create_table "mobile_metadata", force: :cascade do |t|
     t.string "environment"
@@ -45,7 +83,7 @@ ActiveRecord::Schema.define(version: 2018_11_08_031609) do
     t.string "police_district"
     t.float "lat"
     t.float "long"
-    t.point "point"
+    t.geography "point", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
     t.string "point_city"
     t.string "source"
     t.string "point_state"

--- a/lanebreach-api/db/seeds.rb
+++ b/lanebreach-api/db/seeds.rb
@@ -1,7 +1,18 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+require 'csv'
+
+# Seed the SF 311 cases table with blocked bike lane incidents
+# from April 2018 onward:
+blocked_lane_cases_csv =
+  Sf311CaseService.get_blocked_bike_lane_case_data(
+    from_datetime: Date.new(2018, 4, 1),
+    limit: 5000,
+    format: :csv
+  )
+
+cases_to_import = []
+
+CSV.parse(blocked_lane_cases_csv, headers: true) do |row|
+  cases_to_import << Sf311Case.new(row.to_h)
+end
+
+Sf311Case.import!(cases_to_import)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "db:reset": "docker exec -it lbapi bash -c 'rails db:migrate:reset RAILS_ENV=development'",
     "db:migrate": "docker exec -it lbapi bash -c 'rails db:migrate RAILS_ENV=development'",
     "db:run": "docker run --name lbdb lbdb",
-    "db:seed": "docker exec -it lbdb bash -c 'psql bikelanes bikelanes -f /data/bikeway_networks.sql'",
+    "db:seed": "docker exec -it lbapi bash -c 'rails db:seed RAILS_ENV=development'",
     "start": "docker-compose -f docker-compose.yml up"
   },
   "repository": {


### PR DESCRIPTION
## Summary of Changes
- Added logic to `db/seeds.rb` for fetching blocked bike lane case data and seeding the `sf311_cases` table
- Replaced the `Sf311CasesController#index` action with a database query instead of an API request now that 311 case data is available in the database
- Converted the ActiveRecord database adapter to `postgis` per [the instructions in the PostGIS adapter gem documentation](https://github.com/rgeo/activerecord-postgis-adapter#databaseyml)
- Updated the `Sf311Case#point` datatype from `point` to `st_point` based on [the PostGIS adapter gem documentation](https://github.com/rgeo/activerecord-postgis-adapter#databaseyml)