### PR TITLE
Add support for Heroku container deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,11 @@ services:
       - '5432:5432'
 
   lbapi: &lbapi
+    image: lanebreach_api
     container_name: lbapi
     build:
       context: ./lanebreach-api
-      dockerfile: Dockerfile
-    image: lanebreach_api
+      dockerfile: Dockerfile.web
     environment:
       RAILS_DATABASE_HOST: lbdb
       REDIS_URL: redis://redis:6379
@@ -24,16 +24,17 @@ services:
       - '3000:3000'
     depends_on:
       - lbdb
-    command: bundle exec puma
 
   worker:
     <<: *lbapi
     container_name: worker
+    build:
+      context: ./lanebreach-api
+      dockerfile: Dockerfile.worker
     image: lanebreach_worker
     ports: []
     depends_on:
       - redis
-    command: bundle exec sidekiq
 
   redis:
     image: redis:5.0-alpine

--- a/lanebreach-api/Dockerfile.web
+++ b/lanebreach-api/Dockerfile.web
@@ -2,7 +2,7 @@ FROM ruby:2.5.1
 
 ARG PORT=3000
 
-# Setup the api application
+# Setup the API application
 RUN mkdir /lanebreach-api
 WORKDIR /lanebreach-api
 ADD Gemfile /lanebreach-api/Gemfile
@@ -12,3 +12,5 @@ ADD . /lanebreach-api
 
 EXPOSE $PORT
 ENV RAILS_LOG_TO_STDOUT true
+
+CMD bundle exec puma

--- a/lanebreach-api/Dockerfile.worker
+++ b/lanebreach-api/Dockerfile.worker
@@ -1,0 +1,13 @@
+FROM ruby:2.5.1
+
+# Setup the API application
+RUN mkdir /lanebreach-api
+WORKDIR /lanebreach-api
+ADD Gemfile /lanebreach-api/Gemfile
+ADD Gemfile.lock /lanebreach-api/Gemfile.lock
+RUN bundle install
+ADD . /lanebreach-api
+
+ENV RAILS_LOG_TO_STDOUT true
+
+CMD bundle exec sidekiq

--- a/lanebreach-api/README.md
+++ b/lanebreach-api/README.md
@@ -2,8 +2,14 @@
 
 The app lives on Heroku at https://lane-breach.herokuapp.com/ which you must be logged into to deploy. Make sure to add the heroku remote using ```heroku git:remote -a lane-breach```.
 
-* You can push a new version of the app using ```git subtree push --prefix lanebreach-api heroku master```.
-* You can run migrations using ```heroku run rake db:migrate```.
+* You can push a new version of the app by running the following commands:
+
+```
+heroku container:push --recursive
+heroku container:release web worker
+```
+
+* You can run migrations using ```heroku run rails db:migrate```.
 
 ## Development
 
@@ -15,7 +21,7 @@ Run `yarn start` to run the Rails server locally. Be sure you have the Docker ag
 
 #### GET /api/mobile_metadata
 
-**request:** 
+**request:**
 ```
 curl -XGET https://lane-breach.herokuapp.com/api/mobile_metadata
 ```

--- a/lanebreach-api/app/models/sf311_case.rb
+++ b/lanebreach-api/app/models/sf311_case.rb
@@ -39,7 +39,7 @@
 require 'csv'
 
 class Sf311Case < ApplicationRecord
-  has_one :sf311_case_metadatum
+  has_one :sf311_case_metadatum, dependent: :destroy
 
   validates :service_request_id, uniqueness: true
 

--- a/lanebreach-api/app/models/sf311_case.rb
+++ b/lanebreach-api/app/models/sf311_case.rb
@@ -36,6 +36,8 @@
 #  index_sf311_cases_on_service_request_id  (service_request_id) UNIQUE
 #
 
+require 'csv'
+
 class Sf311Case < ApplicationRecord
   has_one :sf311_case_metadatum
 

--- a/lanebreach-api/app/workers/ingest_latest_blocked_lane_cases_worker.rb
+++ b/lanebreach-api/app/workers/ingest_latest_blocked_lane_cases_worker.rb
@@ -2,25 +2,21 @@ class IngestLatestBlockedLaneCasesWorker
   include Sidekiq::Worker
 
   def perform
-    # 1. Fetch timestamp of most recently retrieved case
-    #   - Store in either Redis or retrieve most recent date from cases table
-    most_recent_case_timestamp = Sf311Case.last.requested_datetime
+    # 1. Fetch the timestamp of most recently retrieved case:
+    most_recent_case = Sf311Case.order(:requested_datetime).last
 
-    # 2. Fetch all blocked bike lane cases between the above timestamp + 1 minute
-    #    and the current date
+    most_recent_case_timestamp =
+      most_recent_case&.requested_datetime || 1.week.ago
+
+    # 2. Fetch all blocked bike lane cases between the above
+    #    timestamp + 1 minute and the current date:
     blocked_lane_cases_csv =
       Sf311CaseService.get_blocked_bike_lane_case_data(
         from_datetime: most_recent_case_timestamp + 1.minute,
-
-        # TODO: Figure out record limit keeping in mind that seeds.rb currently
-        # adds the first 50 records since April 2018
-        # limit: 5000,
-
         format: :csv
       )
 
-    # 3. Ingest the records retrieved in step 2 (may want to use and/or
-    #    move the code used to do this in db/seeds.rb)
+    # 3. Ingest the records retrieved in step 2:
     Sf311Case.ingest_csv_case_data!(blocked_lane_cases_csv)
   end
 end

--- a/lanebreach-api/config/initializers/sidekiq.rb
+++ b/lanebreach-api/config/initializers/sidekiq.rb
@@ -1,6 +1,15 @@
-# Set up the Sidekiq CRON schedule:
-schedule_filename = 'config/schedule.yml'
+# Connect the Sidekiq client and server to Redis:
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV['REDIS_URL'] }
+end
 
-if File.exist?(schedule_filename) && Sidekiq.server?
-  Sidekiq::Cron::Job.load_from_hash(YAML.load_file(schedule_filename))
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV['REDIS_URL'] }
+end
+
+# Set up the Sidekiq CRON schedule:
+SCHEDULE_FILENAME = 'config/schedule.yml'
+
+if File.exist?(SCHEDULE_FILENAME) && Sidekiq.server?
+  Sidekiq::Cron::Job.load_from_hash(YAML.load_file(SCHEDULE_FILENAME))
 end


### PR DESCRIPTION
Per [Heroku's container registry documentation](https://devcenter.heroku.com/articles/container-registry-and-runtime), I've added separate Dockerfiles for the `web` and `worker` images.

Other miscelleneous changes:
* Added a cascading delete directive to the `Sf311Case` model from removing case metadata
* Fixed a couple minor issues in the case ingestion worker
* Added sidekiq initialization code for connecting to Redis